### PR TITLE
Rename tests with game mode prefix

### DIFF
--- a/code/testsuite/PCGfiles/35e_Bob.pcg
+++ b/code/testsuite/PCGfiles/35e_Bob.pcg
@@ -168,7 +168,7 @@ CHARACTERDMNOTES:
 # Kits
 
 # Character Master/Follower
-FOLLOWER:Companion Mod|TYPE:Companion Mod|RACE:COMPANION|HITDICE:0|FILE:Bob Companion.pcg
+FOLLOWER:Companion Mod|TYPE:Companion Mod|RACE:COMPANION|HITDICE:0|FILE:35e_Bob_Companion.pcg
 
 # Character Notes Tab
 NOTE:Character Sheet Notes|ID:1|PARENTID:-1|VALUE:

--- a/code/testsuite/PCGfiles/35e_Quasvin.pcg
+++ b/code/testsuite/PCGfiles/35e_Quasvin.pcg
@@ -239,7 +239,7 @@ CHARACTERDMNOTES:
 # Kits
 
 # Character Master/Follower
-FOLLOWER:Q-PsiCrystal|TYPE:Psicrystal|RACE:PSICRYSTAL (COWARD)|HITDICE:0|FILE:Q-PsiCrystal.pcg
+FOLLOWER:Q-PsiCrystal|TYPE:Psicrystal|RACE:PSICRYSTAL (COWARD)|HITDICE:0|FILE:35e_Q-PsiCrystal.pcg
 
 # Character Notes Tab
 NOTE:Character Sheet Notes|ID:1|PARENTID:-1|VALUE:


### PR DESCRIPTION
Changed FOLLOWER file in 35e_Bob.pcg to 35e_Bob_Companion.pcg

Changed FOLLOWER file in 35e_Quasvin.pcg to 35e_Q-PsiCrystal.pcg

N.B. LOADCOMPANIONS:N in 35e_Quasvin.pcg.  Should an incorrect file
name for
35e_Q-PsiCrystal.pcg have caused the build to fail?

:slowtest
:buildDashboard UP-TO-DATE

BUILD SUCCESSFUL

Total time: 21 mins 45.422 secs
